### PR TITLE
Make generated visitor id random to prevent collisions

### DIFF
--- a/flagship/dist-deno/src/visitor/VisitorAbstract.ts
+++ b/flagship/dist-deno/src/visitor/VisitorAbstract.ts
@@ -42,7 +42,7 @@ export abstract class VisitorAbstract extends EventEmitter implements IVisitor {
     this._configManager = configManager
 
     const VisitorCache = this.config.enableClientCache ? cacheVisitor.loadVisitorProfile() : null
-    this.visitorId = visitorId || VisitorCache?.visitorId || this.createVisitorId()
+    this.visitorId = visitorId || VisitorCache?.visitorId || this.uuidV4()
 
     this.setConsent(hasConsented ?? true)
 
@@ -124,16 +124,6 @@ export abstract class VisitorAbstract extends EventEmitter implements IVisitor {
       const value = char === 'x' ? rand : (rand & 0x3 | 0x8)
       return value.toString(16)
     })
-  }
-
-  protected createVisitorId (): string {
-    const now = new Date()
-    const random = Math.floor(Math.random() * (99999 - 10000) + 10000)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const twoDigits = (value: any): any => (value.toString().length === 1 ? `0${value}` : value)
-    return `${now.getFullYear()}${twoDigits(now.getMonth() + 1)}${twoDigits(now.getDate())}${twoDigits(now.getHours())}${twoDigits(
-      now.getMinutes()
-    )}${random}`
   }
 
   public get visitorId (): string {

--- a/flagship/src/visitor/VisitorAbstract.ts
+++ b/flagship/src/visitor/VisitorAbstract.ts
@@ -42,7 +42,7 @@ export abstract class VisitorAbstract extends EventEmitter implements IVisitor {
     this._configManager = configManager
 
     const VisitorCache = this.config.enableClientCache ? cacheVisitor.loadVisitorProfile() : null
-    this.visitorId = visitorId || VisitorCache?.visitorId || this.createVisitorId()
+    this.visitorId = visitorId || VisitorCache?.visitorId || this.uuidV4()
 
     this.setConsent(hasConsented ?? true)
 
@@ -124,16 +124,6 @@ export abstract class VisitorAbstract extends EventEmitter implements IVisitor {
       const value = char === 'x' ? rand : (rand & 0x3 | 0x8)
       return value.toString(16)
     })
-  }
-
-  protected createVisitorId (): string {
-    const now = new Date()
-    const random = Math.floor(Math.random() * (99999 - 10000) + 10000)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const twoDigits = (value: any): any => (value.toString().length === 1 ? `0${value}` : value)
-    return `${now.getFullYear()}${twoDigits(now.getMonth() + 1)}${twoDigits(now.getDate())}${twoDigits(now.getHours())}${twoDigits(
-      now.getMinutes()
-    )}${random}`
   }
 
   public get visitorId (): string {


### PR DESCRIPTION
Right now, if you do not specify a visitor id, it will autogenerate
a visitor id based on a date, down to the minute, and then tack on
a random number between 10,000 and 99,999.

This is not great because it has a high probability of collisions.

For example, given ther 86,400 seconds in a day, if you have 2 new
visitors hitting flagship a second, there's a 67% chance that you'll
have a collision. See here for calculations:
https://www.calculator.net/probability-calculator.html?cal4pa=0.00001111111&cal4par=86400&cal4pb=0&cal4pbr=0&calctype=series&x=19&y=16#series

The fix here is to simply use uuids, which has a 1 in 2.71 quatillion chance
of collision.