### PR TITLE
feat: Implement empty sendActivate method in NotReadyStrategy

### DIFF
--- a/flagship/package.json
+++ b/flagship/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flagship.io/js-sdk",
   "sideEffects": false,
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "Apache-2.0",
   "description": "Flagship JS SDK",
   "main": "dist/index.cjs",

--- a/flagship/src/visitor/NoConsentStrategy.ts
+++ b/flagship/src/visitor/NoConsentStrategy.ts
@@ -1,4 +1,4 @@
-import { CampaignDTO, IHit } from '../types'
+import { CampaignDTO, FlagDTO, IHit } from '../types'
 import { FLAG_VISITOR_EXPOSED, METHOD_DEACTIVATED_CONSENT_ERROR } from '../enum/index'
 import { HitAbstract } from '../hit/index'
 import { logInfo, sprintf } from '../utils/utils'
@@ -35,6 +35,11 @@ export class NoConsentStrategy extends DefaultStrategy {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async sendHits (_hits: HitAbstract[] | IHit[] |BatchDTO[]): Promise<void> {
     this.log('sendHits')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async sendActivate (_flagDto: FlagDTO, _defaultValue?: unknown): Promise<void> {
+    //
   }
 
   async visitorExposed (): Promise<void> {

--- a/flagship/src/visitor/NotReadyStrategy.ts
+++ b/flagship/src/visitor/NotReadyStrategy.ts
@@ -50,6 +50,11 @@ export class NotReadyStrategy extends DefaultStrategy {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async sendActivate (_flagDto: FlagDTO, _defaultValue?: unknown): Promise<void> {
+    //
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async sendTroubleshootingHit (_hit: Troubleshooting): Promise<void> {
     //
   }

--- a/flagship/src/visitor/PanicStrategy.ts
+++ b/flagship/src/visitor/PanicStrategy.ts
@@ -75,6 +75,11 @@ export class PanicStrategy extends DefaultStrategy {
     //
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected async sendActivate (_flagDto: FlagDTO, _defaultValue?: unknown): Promise<void> {
+    //
+  }
+
   private log (methodName:string) {
     logInfoSprintf(this.config, methodName, METHOD_DEACTIVATED_ERROR, this.visitor.visitorId, methodName, FSSdkStatus[FSSdkStatus.SDK_PANIC])
   }


### PR DESCRIPTION
Note: This commit adds an empty implementation for the sendActivate method in NotReadyStrategy class.